### PR TITLE
Allow for downloading artifacts that are in sub-directories

### DIFF
--- a/appveyor_artifacts.py
+++ b/appveyor_artifacts.py
@@ -478,6 +478,10 @@ def download_file(local_path, url, expected_size, chunk_size, log):
 
     # Download file.
     log.debug('Writing to: %s', local_path)
+    local_directory = os.path.dirname(local_path)
+    if not os.path.exists(local_directory):
+        log.debug('Creating directory: %s', local_directory)
+        os.makedirs(local_directory)
     with open(local_path, 'wb') as handle:
         response = requests.get(url, stream=True)
         for chunk in response.iter_content(chunk_size):

--- a/tests/test_download_file.py
+++ b/tests/test_download_file.py
@@ -48,3 +48,23 @@ def test_errors(tmpdir, caplog, file_exists):
     else:
         message = 'Expected {0} bytes but got {1} bytes instead.'.format(source_file.size() + 32, source_file.size())
         assert caplog.records()[-2].message == message
+
+
+@pytest.mark.httpretty
+def test_create_directory(capsys, tmpdir):
+    """Sub-directory should be created to store the target file..."""
+    # Prepare requests module mocking.
+    source_file = py.path.local(__file__).dirpath().join('..', 'appveyor_artifacts.py')
+    url = 'https://ci.appveyor.com/api/buildjobs/abc1def2ghi3jkl4/artifacts/appveyor_artifacts.py'
+    httpretty.register_uri(httpretty.GET, url, body=iter(source_file.readlines()), streaming=True)
+
+    # Run.
+    local_path = tmpdir.join('moo', 'appveyor_artifacts.py')
+    download_file(str(local_path), url, source_file.size(), 1024)
+
+    # Check.
+    assert local_path.size() == source_file.size()
+    assert local_path.computehash() == source_file.computehash()
+    stdout, stderr = capsys.readouterr()
+    assert not stdout
+    assert re.match(r'^ => appveyor_artifacts.py [\.]{15,79} [\d]{5,6} bytes\n$', stderr)


### PR DESCRIPTION
This change-set just adds the ability to download artifacts that are stored in subdirectories. In particular when using Appveyor to build wheels for Windows your artifacts will often be in "dist" subdirectories.
