### PR TITLE
Fix path mangling for coverage >= 4.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 
 # Run.
 install: pip install coveralls tox
-script: tox -e lint,py35,py34,py33,pypy3,pypy,py27
+script: tox -e lint,py35,py34,py33,pypy3.3-5.2-alpha1,pypy,py27
 after_success: coveralls
 
 # Deploy.

--- a/appveyor_artifacts.py
+++ b/appveyor_artifacts.py
@@ -62,7 +62,7 @@ API_PREFIX = 'https://ci.appveyor.com/api'
 QUERY_ATTEMPTS = 3
 REGEX_COMMIT = re.compile(r'^[0-9a-f]{7,40}$')
 REGEX_GENERAL = re.compile(r'^[0-9a-zA-Z\._-]+$')
-REGEX_MANGLE = re.compile(r'"(C:\\\\projects\\\\(?:(?!": \[).)+)')  # http://stackoverflow.com/a/17089058/1198943
+REGEX_MANGLE = re.compile(r'"(C:\\\\projects\\\\(?:(?!":\[).)+)')  # http://stackoverflow.com/a/17089058/1198943
 SLEEP_FOR = 10
 
 

--- a/tests/test_mangle_coverage.py
+++ b/tests/test_mangle_coverage.py
@@ -28,8 +28,8 @@ def test_file_not_found(tmpdir, caplog):
     """
     local_path = tmpdir.join('.coverage')
     local_path.write(
-        '!coverage.py: This is a private format, don\'t read it directly!{"arcs": {"C:\\\\projects\\\\'
-        'colorclass\\\\colorclass.py": [[516, 509], [398, 401], [173, 174], [-1, 380]]}}'
+        '!coverage.py: This is a private format, don\'t read it directly!{"arcs":{"C:\\\\projects\\\\'
+        'colorclass\\\\colorclass.py":[[516,509],[398,401],[173,174],[-1,380]]}}'
     )
     old_hash = local_path.computehash()
 
@@ -46,8 +46,8 @@ def test_success(tmpdir):
     """
     local_path = tmpdir.join('.coverage')
     local_path.write(
-        '!coverage.py: This is a private format, don\'t read it directly!{"arcs": {"C:\\\\projects\\\\'
-        'appveyor_artifacts\\\\appveyor_artifacts.py": [[516, 509], [398, 401], [173, 174], [-1, 380]]}}'
+        '!coverage.py: This is a private format, don\'t read it directly!{"arcs":{"C:\\\\projects\\\\'
+        'appveyor_artifacts\\\\appveyor_artifacts.py":[[516,509],[398,401],[173,174],[-1,380]]}}'
     )
     old_hash = local_path.computehash()
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ name = appveyor_artifacts
 version = 1.0.2
 
 [tox]
-envlist = lint,py{34,27}
+envlist = lint,py{34,27},pypy3.3-5.2-alpha1
 
 [testenv]
 commands =


### PR DESCRIPTION
Since version 4.3.0 the spaces in the .coverage files have been removed.
Path mangling would then fail, making the coveralls upload fail too,
as the paths were not properly updated.

The related commit in the coverage project is:
"Omit needless whitespace in json-based data files"
477346880dcf298556c8fb9bf3a42cd39b58cbcf

Here is an example of the change in the .coverage file:
OLD: “C:\\projects\\projectname\\file1.py": [],"C:\\projects\\projectname\\file2.py": [64,67]
NEW: "C:\\projects\\projectname\\file1.py":[],"C:\\projects\\projectname\\file2.py":[64,67]

The tests have been adapted for the new file format.
    
pypy3.3-5.2-alpha1 is used as Travis is now using pypy3, which
is broken with pip - setuptools.