### PR TITLE
Add "token" argument for private repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 # Configure.
 language: python
-python: 3.5
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "pypy"
 sudo: false
 
 # Run.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,25 @@
 # Configure.
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "pypy"
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: pypy
+      env: TOXENV=pypy
+    - python: pypy3
+      env: TOXENV=pypy3.3-5.2-alpha1
+    - env: TOXENV=lint
 sudo: false
 
 # Run.
 install: pip install coveralls tox
-script: tox -e lint,py35,py34,py33,pypy3.3-5.2-alpha1,pypy,py27
+script: tox
 after_success: coveralls
 
 # Deploy.

--- a/appveyor_artifacts.py
+++ b/appveyor_artifacts.py
@@ -519,10 +519,15 @@ def download_file(config, local_path, url, expected_size, chunk_size, log):
     relative_path = os.path.relpath(local_path, config['dir'] or os.getcwd())
     print(' => {0}'.format(relative_path), end=' ', file=sys.stderr)
 
+    headers = {}
+    if config['token']:
+        headers['authorization'] = 'Bearer ' + config['token']
+
     # Download file.
     log.debug('Writing to: %s', local_path)
     with open(local_path, 'wb') as handle:
-        response = requests.get(url, stream=True)
+
+        response = requests.get(url, headers=headers, stream=True)
         for chunk in response.iter_content(chunk_size):
             handle.write(chunk)
             print('.', end='', file=sys.stderr)

--- a/appveyor_artifacts.py
+++ b/appveyor_artifacts.py
@@ -53,6 +53,7 @@ import time
 import pkg_resources
 import requests
 import requests.exceptions
+import requests.utils
 from docopt import docopt
 
 __author__ = '@Robpol86'
@@ -423,7 +424,8 @@ def artifacts_urls(config, jobs_artifacts, log):
     # Get final URLs and destination file paths.
     root_dir = config['dir'] or os.getcwd()
     for job, file_name, size in jobs_artifacts:
-        artifact_url = '{0}/buildjobs/{1}/artifacts/{2}'.format(API_PREFIX, job, file_name)
+        file_name_urlsafe = requests.utils.quote(file_name, safe='')
+        artifact_url = '{0}/buildjobs/{1}/artifacts/{2}'.format(API_PREFIX, job, file_name_urlsafe)
         artifact_local = os.path.join(root_dir, job if job_dirs else '', file_name)
         if artifact_local in artifacts:
             if config['no_job_dirs'] == 'skip':

--- a/appveyor_artifacts.py
+++ b/appveyor_artifacts.py
@@ -33,6 +33,7 @@ Options:
     -N JOB --job-name=JOB       Filter by job name (Python versions, etc).
     -o NAME --owner-name=NAME   Repository owner/account name.
     -p NUM --pull-request=NUM   Pull request number of current job.
+    -s TOKEN --token=TOKEN      AppVeyor API token
     -r --raise                  Don't handle exceptions, raise all the way.
     -t NAME --tag-name=NAME     Tag name that triggered current job.
     -v --verbose                Raise exceptions with tracebacks.

--- a/appveyor_artifacts.py
+++ b/appveyor_artifacts.py
@@ -193,6 +193,7 @@ def get_arguments(argv=None, environ=None):
         'raise': args['--raise'],
         'repo': repo,
         'tag': tag,
+        'token': args['--token'] or '',
         'verbose': args['--verbose'],
     }
 

--- a/tests/test_artifacts_urls.py
+++ b/tests/test_artifacts_urls.py
@@ -165,9 +165,9 @@ def test_subdirectory():
     actual = artifacts_urls(config, jobs_artifacts)
     expected = dict([
         (py.path.local('src/OutputRoot/PackageWeb.1.1.17.nupkg'),
-         (API_PREFIX + '/buildjobs/r97evl3jva2ejs6b/artifacts/src/OutputRoot/PackageWeb.1.1.17.nupkg', 60301)),
+         (API_PREFIX + '/buildjobs/r97evl3jva2ejs6b/artifacts/src%2FOutputRoot%2FPackageWeb.1.1.17.nupkg', 60301)),
         (py.path.local('src/OutputRoot/PackageWeb.1.1.10.nupkg'),
-         (API_PREFIX + '/buildjobs/s97evl3jva2ejs6b/artifacts/src/OutputRoot/PackageWeb.1.1.10.nupkg', 50301)),
+         (API_PREFIX + '/buildjobs/s97evl3jva2ejs6b/artifacts/src%2FOutputRoot%2FPackageWeb.1.1.10.nupkg', 50301)),
     ])
     assert actual == expected
 

--- a/tests/test_download_file.py
+++ b/tests/test_download_file.py
@@ -23,7 +23,8 @@ def test_success(capsys, tmpdir):
 
     # Run.
     local_path = tmpdir.join('appveyor_artifacts.py')
-    download_file(dict(dir=str(tmpdir)), str(local_path), url, source_file.size(), 1024)
+    config = dict(dir=str(tmpdir), token='')
+    download_file(config, str(local_path), url, source_file.size(), 1024)
 
     # Check.
     assert local_path.size() == source_file.size()
@@ -47,7 +48,8 @@ def test_success_subdir(capsys, tmpdir):
 
     # Run.
     local_path = tmpdir.join('src', 'files', 'appveyor_artifacts.py')
-    download_file(dict(dir=str(tmpdir)), str(local_path), url, source_file.size(), 1024)
+    config = dict(dir=str(tmpdir), token='')
+    download_file(config, str(local_path), url, source_file.size(), 1024)
 
     # Check.
     assert local_path.size() == source_file.size()
@@ -70,11 +72,13 @@ def test_errors(tmpdir, caplog, file_exists):
     url = 'https://ci.appveyor.com/api/buildjobs/abc1def2ghi3jkl4/artifacts/appveyor_artifacts.py'
     httpretty.register_uri(httpretty.GET, url, body=iter(source_file.readlines()), streaming=True)
 
+    config = dict(dir=str(tmpdir), token='')
+
     local_path = tmpdir.join('appveyor_artifacts.py')
     if file_exists:
         local_path.ensure()
     with pytest.raises(HandledError):
-        download_file(dict(dir=str(tmpdir)), str(local_path), url, source_file.size() + 32, 1024)
+        download_file(config, str(local_path), url, source_file.size() + 32, 1024)
 
     if file_exists:
         assert caplog.records[-2].message == 'File already exists: ' + str(local_path)

--- a/tests/test_get_arguments.py
+++ b/tests/test_get_arguments.py
@@ -37,6 +37,7 @@ def different_cli_argv():
         'raise': False,
         'repo': '',
         'tag': '',
+        'token': '',
         'verbose': False,
     }
     yield argv, expected
@@ -62,6 +63,7 @@ def different_cli_argv():
         'raise': False,
         'repo': 'koala',
         'tag': 'v1.0.0',
+        'token': '',
         'verbose': False,
         'ignore_errors': False,
     }
@@ -74,6 +76,7 @@ def different_cli_argv():
         '-J', 'overwrite',
         '-m',
         '-N', r'Environment: PYTHON=C:\Python27',
+        '-s', 'aSecret',
         '-v',
     ]
     expected = {
@@ -89,6 +92,7 @@ def different_cli_argv():
         'raise': False,
         'repo': '',
         'tag': '',
+        'token': 'aSecret',
         'verbose': True,
     }
     yield argv, expected

--- a/tests/test_get_urls.py
+++ b/tests/test_get_urls.py
@@ -15,12 +15,12 @@ def test_instant_success(monkeypatch, artifacts):
     :param monkeypatch: pytest fixture.
     :param bool artifacts: If simulation should have or lack artifacts.
     """
-    monkeypatch.setattr('appveyor_artifacts.query_build_version', lambda _: '1.0.1')
+    monkeypatch.setattr('appveyor_artifacts.query_build_version', lambda *_: '1.0.1')
     monkeypatch.setattr('appveyor_artifacts.query_job_ids', lambda *_: [('abc1def2ghi3jkl4', 'success')])
     monkeypatch.setattr('appveyor_artifacts.query_artifacts',
-                        lambda _: [('abc1def2ghi3jkl4', 'README.md', 1234)] if artifacts else [])
+                        lambda *_: [('abc1def2ghi3jkl4', 'README.md', 1234)] if artifacts else [])
 
-    config = dict(always_job_dirs=False, no_job_dirs=None, dir=None)
+    config = dict(always_job_dirs=False, no_job_dirs=None, dir=None, token='')
     actual = get_urls(config)
     expected = {py.path.local('README.md'): (PREFIX % ('abc1def2ghi3jkl4', 'README.md'), 1234)} if artifacts else dict()
     assert actual == expected
@@ -36,9 +36,9 @@ def test_wait_for_job_queue(monkeypatch, caplog, timeout):
     """
     answers = [None, '1.0.1']
     monkeypatch.setattr('appveyor_artifacts.SLEEP_FOR', 0.01)
-    monkeypatch.setattr('appveyor_artifacts.query_build_version', lambda _: None if timeout else answers.pop(0))
+    monkeypatch.setattr('appveyor_artifacts.query_build_version', lambda *_: None if timeout else answers.pop(0))
     monkeypatch.setattr('appveyor_artifacts.query_job_ids', lambda *_: [('abc1def2ghi3jkl4', 'success')])
-    monkeypatch.setattr('appveyor_artifacts.query_artifacts', lambda _: list())
+    monkeypatch.setattr('appveyor_artifacts.query_artifacts', lambda *_: list())
 
     if timeout:
         with pytest.raises(HandledError):
@@ -66,11 +66,11 @@ def test_queued_running_success_or_failed(monkeypatch, caplog, success):
     """
     answers = (['bad'] if success is None else []) + ['queued', 'running'] + (['success'] if success else ['failed'])
     monkeypatch.setattr('appveyor_artifacts.SLEEP_FOR', 0.01)
-    monkeypatch.setattr('appveyor_artifacts.query_build_version', lambda _: '1.0.1')
+    monkeypatch.setattr('appveyor_artifacts.query_build_version', lambda *_: '1.0.1')
     monkeypatch.setattr('appveyor_artifacts.query_job_ids', lambda *_: [('abc1def2ghi3jkl4', answers.pop(0))])
-    monkeypatch.setattr('appveyor_artifacts.query_artifacts', lambda _: [('abc1def2ghi3jkl4', 'README.md', 1234)])
+    monkeypatch.setattr('appveyor_artifacts.query_artifacts', lambda *_: [('abc1def2ghi3jkl4', 'README.md', 1234)])
 
-    config = dict(always_job_dirs=False, no_job_dirs=None, dir=None, owner='me', repo='project')
+    config = dict(always_job_dirs=False, no_job_dirs=None, dir=None, owner='me', repo='project', token='')
     if not success:
         with pytest.raises(HandledError):
             get_urls(config)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,7 +25,7 @@ def test_no_paths(monkeypatch, caplog):
     """
     monkeypatch.setattr('appveyor_artifacts.get_urls', lambda _: dict())
     monkeypatch.setattr('appveyor_artifacts.validate', lambda _: None)
-    appveyor_artifacts.main(dict(dir=None, mangle_coverage=False))
+    appveyor_artifacts.main(dict(dir=None, mangle_coverage=False, token=''))
     assert caplog.records[-2].message == 'No artifacts; nothing to download.'
 
 
@@ -43,7 +43,7 @@ def test_one_file(capsys, monkeypatch, tmpdir, caplog):
         httpretty.register_uri(httpretty.GET, url, body=body, streaming=True)
     monkeypatch.setattr('appveyor_artifacts.get_urls', lambda _: paths_and_urls)
     monkeypatch.setattr('appveyor_artifacts.validate', lambda _: None)
-    appveyor_artifacts.main(dict(dir=str(tmpdir), mangle_coverage=False))
+    appveyor_artifacts.main(dict(dir=str(tmpdir), mangle_coverage=False, token=''))
 
     messages = [r.message for r in caplog.records if r.levelname != 'DEBUG']
     expected = [
@@ -76,7 +76,7 @@ def test_multiple_files(capsys, monkeypatch, tmpdir, caplog):
         httpretty.register_uri(httpretty.GET, url, body=body, streaming=True)
     monkeypatch.setattr('appveyor_artifacts.get_urls', lambda _: paths_and_urls)
     monkeypatch.setattr('appveyor_artifacts.validate', lambda _: None)
-    appveyor_artifacts.main(dict(dir=str(tmpdir), mangle_coverage=False))
+    appveyor_artifacts.main(dict(dir=str(tmpdir), mangle_coverage=False, token=''))
 
     messages = [r.message for r in caplog.records if r.levelname != 'DEBUG']
     expected = [
@@ -116,7 +116,7 @@ def test_small_files(capsys, monkeypatch, tmpdir, caplog):
         httpretty.register_uri(httpretty.GET, url, body=body, streaming=True)
     monkeypatch.setattr('appveyor_artifacts.get_urls', lambda _: paths_and_urls)
     monkeypatch.setattr('appveyor_artifacts.validate', lambda _: None)
-    appveyor_artifacts.main(dict(dir=str(tmpdir), mangle_coverage=False))
+    appveyor_artifacts.main(dict(dir=str(tmpdir), mangle_coverage=False, token=''))
 
     messages = [r.message for r in caplog.records if r.levelname != 'DEBUG']
     expected = [
@@ -154,7 +154,7 @@ def test_large_files(capsys, monkeypatch, tmpdir, caplog):
         httpretty.register_uri(httpretty.GET, url, body=body, streaming=True)
     monkeypatch.setattr('appveyor_artifacts.get_urls', lambda _: paths_and_urls)
     monkeypatch.setattr('appveyor_artifacts.validate', lambda _: None)
-    appveyor_artifacts.main(dict(dir=str(tmpdir), mangle_coverage=True))
+    appveyor_artifacts.main(dict(dir=str(tmpdir), mangle_coverage=True, token=''))
 
     messages = [r.message for r in caplog.records if r.levelname != 'DEBUG']
     expected = [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -172,7 +172,7 @@ def test_large_files(capsys, monkeypatch, tmpdir, caplog):
     assert stderr == expected
 
 
-@pytest.mark.skipif('(os.environ.get("CI"), os.environ.get("TRAVIS")) != ("true", "true")')
+@pytest.mark.skipif((os.environ.get("CI") == True) and (os.environ.get("TRAVIS") == True), reason='on CI')
 @pytest.mark.parametrize('direct', [False, True])
 def test_subprocess(tmpdir, direct):
     """Test executing script through entry_points and directly.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -172,7 +172,7 @@ def test_large_files(capsys, monkeypatch, tmpdir, caplog):
     assert stderr == expected
 
 
-@pytest.mark.skipif((os.environ.get("CI") == True) and (os.environ.get("TRAVIS") == True), reason='on CI')
+@pytest.mark.skipif((os.environ.get("CI") == 'true') and (os.environ.get("TRAVIS") == 'true'), reason='on CI')
 @pytest.mark.parametrize('direct', [False, True])
 def test_subprocess(tmpdir, direct):
     """Test executing script through entry_points and directly.

--- a/tests/test_query_artifacts.py
+++ b/tests/test_query_artifacts.py
@@ -5,10 +5,11 @@ from functools import partial
 from appveyor_artifacts import query_artifacts
 
 
-def mock_query_api(url, replies):
+def mock_query_api(url, token, replies):
     """Mock JSON replies.
 
     :param str url: Url as key.
+    :param str token: Token; ignored
     :param dict replies: Mock replies from test functions.
     """
     return replies[url]
@@ -19,9 +20,13 @@ def test(monkeypatch):
 
     :param monkeypatch: pytest fixture.
     """
+    config = dict(
+        token='',
+    )
+
     # Test empty.
-    monkeypatch.setattr('appveyor_artifacts.query_api', lambda _: list())
-    assert query_artifacts(['spfxkimxcj6faq57']) == list()
+    monkeypatch.setattr('appveyor_artifacts.query_api', lambda _, **kwargs: list())
+    assert query_artifacts(['spfxkimxcj6faq57'], config) == list()
 
     # Test multiple jobs.
     replies = {
@@ -38,8 +43,9 @@ def test(monkeypatch):
             {'fileName': 'no_ext', 'size': 101, 'type': 'File'},
         ],
     }
+
     monkeypatch.setattr('appveyor_artifacts.query_api', partial(mock_query_api, replies=replies))
-    actual = query_artifacts(['v5wnn9k8auqcqovw', 'bpgcbvqmawv1jw06'])
+    actual = query_artifacts(['v5wnn9k8auqcqovw', 'bpgcbvqmawv1jw06'], config)
 
     expected = [
         ('v5wnn9k8auqcqovw', 'luajit.exe', 675840),

--- a/tests/test_query_build_version.py
+++ b/tests/test_query_build_version.py
@@ -7,10 +7,11 @@ import pytest
 from appveyor_artifacts import HandledError, query_build_version
 
 
-def mock_query_api(url, replies):
+def mock_query_api(url, token, replies):
     """Mock JSON replies.
 
     :param str url: Url as key.
+    :param str token: Token; ignored
     :param dict replies: Mock replies from test functions.
     """
     return replies[url]
@@ -43,6 +44,7 @@ def test_success(monkeypatch, caplog, kind):
         pull_request='12' if kind == 'pull request' else '',
         repo='repo',
         tag='v2.0.0' if kind == 'tag' else '',
+        token='',
     )
 
     actual = query_build_version(config)
@@ -82,6 +84,7 @@ def test_empty(monkeypatch):
         pull_request=None,
         repo='repo',
         tag='',
+        token='',
     )
 
     actual = query_build_version(config)
@@ -113,6 +116,7 @@ def test_errors(monkeypatch, caplog):
         pull_request=None,
         repo='repo',
         tag='',
+        token='',
     )
 
     with pytest.raises(HandledError):

--- a/tests/test_query_job_ids.py
+++ b/tests/test_query_job_ids.py
@@ -7,10 +7,11 @@ import pytest
 from appveyor_artifacts import HandledError, query_job_ids
 
 
-def mock_query_api(url, replies):
+def mock_query_api(url, token, replies):
     """Mock JSON replies.
 
     :param str url: Url as key.
+    :param str token: Token; ignored
     :param dict replies: Mock replies from test functions.
     """
     return replies[url]
@@ -29,7 +30,7 @@ def test_no_name(monkeypatch):
     monkeypatch.setattr('appveyor_artifacts.query_api', partial(mock_query_api, replies=replies))
 
     build_version = '1.0.239'
-    config = dict(job_name='', owner='Robpol86', repo='terminaltables')
+    config = dict(job_name='', owner='Robpol86', repo='terminaltables', token='')
 
     actual = query_job_ids(build_version, config)
     expected = [('ocw0l628ww5yqqxy', 'success')]
@@ -57,7 +58,7 @@ def test_multiple_jobs(monkeypatch, caplog, job_name):
     monkeypatch.setattr('appveyor_artifacts.query_api', partial(mock_query_api, replies=replies))
 
     build_version = '1.0.9'
-    config = dict(job_name=job_name, owner='Robpol86', repo='flask-statics-helper')
+    config = dict(job_name=job_name, owner='Robpol86', repo='flask-statics-helper', token='')
 
     actual = query_job_ids(build_version, config)
     if job_name:
@@ -92,7 +93,7 @@ def test_errors(monkeypatch, caplog):
     monkeypatch.setattr('appveyor_artifacts.query_api', partial(mock_query_api, replies=replies))
 
     build_version = '1.6.0.43'
-    config = dict(job_name='unknown', owner='user', repo='repo')
+    config = dict(job_name='unknown', owner='user', repo='repo', token='')
 
     with pytest.raises(HandledError):
         query_job_ids(build_version, config)

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ commands =
     py.test --cov-append --cov-report term-missing --cov-report xml --cov {[general]name} --cov-config tox.ini \
         {posargs:tests}
 deps =
+    pytest==3.0.5
     pytest-catchlog==1.2.2
     pytest-cov==2.2.1
     pytest-httpretty==0.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ version = 1.0.2
 
 [tox]
 envlist = lint,py{34,27},pypy3.3-5.2-alpha1
+skip_missing_interpreters=true
 
 [testenv]
 commands =


### PR DESCRIPTION
This aims to add a `--token` argument, for the AppVeyor API token, so `appveyor-downloads` works for private repositories.

The tests did not currently pass on Travis, because of some changes in dependencies, so this includes some changes to the tox and travis configuration.

Also resolves #9 Url-escape artifact 'filename'

~~I still want to do some real-world testing, but otherwise this is ready afaic~~

This works for my private repository now.
